### PR TITLE
Versatile Text Length for the `format` directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test.inc
 test.pory
 poryscript.exe
+poryscript

--- a/README.md
+++ b/README.md
@@ -322,6 +322,26 @@ Becomes:
 ```
 The font widths configuration JSON file informs Poryscript how many pixels wide each character in the message is. Different fonts have different character widths. For convenience, Poryscript comes with `font_widths.json`, which contains the configuration for pokeemerald's `1_latin` font. More fonts can easily be added to this file by the user by creating anothing font id node under the `fonts` key in `font_widths.json`.
 
+The length of a line can optionally be specified as the third parameter to `format()` if a font id was specified as the second parameter.
+
+```
+text MyText {
+    format("Hello, are you the real-live legendary {PLAYER} that everyone talks about?\pAmazing!\pSo glad to meet you!", "1_latin", 100)
+}
+```
+Becomes:
+```
+.string "Hello, are you the\n"
+.string "real-live\l"
+.string "legendary\l"
+.string "{PLAYER} that\l"
+.string "everyone talks\l"
+.string "about?\p"
+.string "Amazing!\p"
+.string "So glad to meet\n"
+.string "you!$"
+```
+
 ## `movement` Statement
 Use `movement` statements to conveniently define movement data that is typically used with the `applymovement` command. `*` can be used as a shortcut to repeat a single command many times. Data defined with `movement` is created with local scope, not global.
 ```

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -893,7 +893,7 @@ func (p *Parser) parseFormatStringOperator() (string, error) {
 		}
 		num, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
 		if err != nil {
-			return "", fmt.Errorf("line %d: invalid format() maxLineLen '%s'. Expected integer", p.curToken.LineNumber, p.curToken.Literal, err.Error())
+			return "", fmt.Errorf("line %d: invalid format() maxLineLen '%s'. Expected integer", p.curToken.LineNumber, p.curToken.Literal)
 		}
 		maxTextLength = int(num)
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -889,18 +889,12 @@ func (p *Parser) parseFormatStringOperator() (string, error) {
 				if err := p.expectPeek(token.INT); err != nil {
 					return "", fmt.Errorf("line %d: invalid format() maxLineLength '%s'. Expected integer", p.peekToken.LineNumber, p.peekToken.Literal)
 				}
-				num, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
-				if err != nil {
-					return "", fmt.Errorf("line %d: invalid format() maxLineLength '%s'. Expected integer", p.curToken.LineNumber, p.curToken.Literal)
-				}
+				num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
 				maxTextLength = int(num)
 			}
 		} else if p.peekTokenIs(token.INT) {
 			p.nextToken()
-			num, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
-			if err != nil {
-				return "", fmt.Errorf("line %d: invalid format() maxLineLength '%s'. Expected integer", p.curToken.LineNumber, p.curToken.Literal)
-			}
+			num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
 			maxTextLength = int(num)
 			if p.peekTokenIs(token.COMMA) {
 				p.nextToken()

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -885,6 +885,18 @@ func (p *Parser) parseFormatStringOperator() (string, error) {
 		fontID = p.curToken.Literal
 		setFontID = true
 	}
+	maxTextLength := 208
+	if p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		if err := p.expectPeek(token.INT); err != nil {
+			return "", fmt.Errorf("line %d: invalid format() maxLineLen '%s'. Expected integer", p.peekToken.LineNumber, p.peekToken.Literal)
+		}
+		num, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
+		if err != nil {
+			return "", fmt.Errorf("line %d: invalid format() maxLineLen '%s'. Expected integer", p.curToken.LineNumber, p.curToken.Literal, err.Error())
+		}
+		maxTextLength = int(num)
+	}
 	if err := p.expectPeek(token.RPAREN); err != nil {
 		return "", fmt.Errorf("line %d: missing closing parenthesis ')' for format()", p.peekToken.LineNumber)
 	}
@@ -898,7 +910,7 @@ func (p *Parser) parseFormatStringOperator() (string, error) {
 	if !setFontID {
 		fontID = p.fonts.DefaultFontID
 	}
-	formatted, err := p.fonts.FormatText(rawText, 208, fontID)
+	formatted, err := p.fonts.FormatText(rawText, maxTextLength, fontID)
 	if err != nil {
 		return "", fmt.Errorf("line %d: %s", lineNum, err.Error())
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -654,6 +654,14 @@ script MyScript1 {
 text MyText {
 	format("FooBar", "TEST")
 }
+
+text MyText1 {
+	format("FooBar", "TEST", 100)
+}
+
+text MyText2 {
+	format("FooBar", 100, "TEST")
+}
 `
 	l := lexer.New(input)
 	p := New(l, "../font_widths.json", nil)
@@ -662,14 +670,20 @@ text MyText {
 		t.Fatalf(err.Error())
 	}
 
-	if len(program.Texts) != 2 {
-		t.Fatalf("len(program.Texts) != 2. Got '%d' instead.", len(program.Texts))
+	if len(program.Texts) != 4 {
+		t.Fatalf("len(program.Texts) != 3. Got '%d' instead.", len(program.Texts))
 	}
 	if program.Texts[0].Value != "Test»{BLAH}$" {
 		t.Fatalf("Incorrect format() evaluation. Got '%s' instead of '%s'", program.Texts[0].Value, "Test»{BLAH}$")
 	}
 	if program.Texts[1].Value != "FooBar$" {
 		t.Fatalf("Incorrect format() evaluation. Got '%s' instead of '%s'", program.Texts[1].Value, "FooBar$")
+	}
+	if program.Texts[2].Value != "FooBar$" {
+		t.Fatalf("Incorrect format() evaluation. Got '%s' instead of '%s'", program.Texts[2].Value, "FooBar$")
+	}
+	if program.Texts[3].Value != "FooBar$" {
+		t.Fatalf("Incorrect format() evaluation. Got '%s' instead of '%s'", program.Texts[3].Value, "FooBar$")
 	}
 }
 
@@ -1515,7 +1529,7 @@ text Foo {
 text Foo {
 	format("Hi", )
 }`,
-			expectedError: "line 3: invalid format() fontId ')'. Expected string",
+			expectedError: "line 3: invalid format() parameter ')'. Expected eighter fontId (string) or maxLineLength (integer)",
 		},
 		{
 			input: `
@@ -1529,7 +1543,7 @@ text Foo {
 script Foo {
 	msgbox(format("Hi", ))
 }`,
-			expectedError: "line 3: invalid format() fontId ')'. Expected string",
+			expectedError: "line 3: invalid format() parameter ')'. Expected eighter fontId (string) or maxLineLength (integer)",
 		},
 		{
 			input: `

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1540,6 +1540,20 @@ text Foo {
 		},
 		{
 			input: `
+text Foo {
+	format("Hi", "TEST", "NOT_AN_INT")
+}`,
+			expectedError: "line 3: invalid format() maxLineLength 'NOT_AN_INT'. Expected integer",
+		},
+		{
+			input: `
+text Foo {
+	format("Hi", 100, 42)
+}`,
+			expectedError: "line 3: invalid format() fontId '42'. Expected string",
+		},
+		{
+			input: `
 script Foo {
 	msgbox(format("Hi", ))
 }`,


### PR DESCRIPTION
Allows to specify the maximal text width (in pixels) to the `format` directive granted the font id was specified as the second argument.

Example as taken from the README:
```
text MyText {
    format("Hello, are you the real-live legendary {PLAYER} that everyone talks about?\pAmazing!\pSo glad to meet you!", "1_latin", 100)
}
```
Becomes:
```
.string "Hello, are you the\n"
.string "real-live\l"
.string "legendary\l"
.string "{PLAYER} that\l"
.string "everyone talks\l"
.string "about?\p"
.string "Amazing!\p"
.string "So glad to meet\n"
.string "you!$"
```