### PR TITLE
agbcc-style install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ To automatically convert your Poryscript scripts when compiling a decomp project
 pokeemerald/tools/poryscript/poryscript.exe
 pokeemerald/tools/poryscript/font_widths.json
 ```
+It's also a good idea to add `tools/poryscript` to your `.gitignore` before your next commit.
+
 2. Update the Makefile with these changes (Note, don't add the `+` symbol at the start of the lines. That's just to show the line is being added.):
 ```diff
 + SCRIPT := tools/poryscript/poryscript$(EXE)
@@ -600,7 +602,7 @@ cd your/path/to/poryscript
 go build
 ```
 
-This will create a `poryscript` executable binary in the same directory.
+This will create a `poryscript` executable binary in the same directory. Then you can simply install it into your project by running `./install.sh ../yourprojectname` instead of manually copying the files over, similarly to how agbcc is installed into projects.
 
 ## Running the tests
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+if [ "$1" != "" ]; then
+    mkdir -p $1/tools/poryscript
+    if test -f "poryscript"; then
+        cp poryscript $1/tools/poryscript
+    elif test -f "poryscript.exe"; then
+        cp poryscript.exe $1/tools/poryscript
+    else
+        echo "Could not find executable to install. Try building first!"
+        exit 1
+    fi
+    cp font_widths.json $1/tools/poryscript
+else
+    echo "Usage: install.sh PATH"
+fi


### PR DESCRIPTION
This adds a shell script to allow users easily install a built-from-source poryscript executable (and the font widths file) into a project. This is similar to how agbcc is installed into multiple projects, and is simply a convenience to save people from having to manually copy over built files when updating from upstream or when maintaining their own fork of poryscript. This behavior is now also reflected in `README.md`.

(Of course, this does not at all affect users who simply download from the releases tab.)