### PR TITLE
Mart Top-Level Statement

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -130,6 +130,20 @@ func (ms *MovementStatement) statementNode() {}
 // TokenLiteral returns a string representation of the movement statement.
 func (ms *MovementStatement) TokenLiteral() string { return ms.Token.Literal }
 
+// MartStatement is a Poryscript mart statement.
+// Mart statements represent item data for the pokemart command.
+type MartStatement struct {
+	Token     token.Token
+	Name      *Identifier
+	MartItems []string
+	Scope     token.Type
+}
+
+func (ps *MartStatement) statementNode() {}
+
+// TokenLiteral returns a string representation of the mart statement.
+func (ps *MartStatement) TokenLiteral() string { return ps.Token.Literal }
+
 // BooleanExpression is a part of a boolean expression.
 type BooleanExpression interface {
 	booleanExpressionNode()

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -77,6 +77,13 @@ func (e *Emitter) Emit() (string, error) {
 			continue
 		}
 
+		martStmt, ok := stmt.(*ast.MartStatement)
+		if ok {
+			sb.WriteString(emitMartStatement(martStmt))
+			i++
+			continue
+		}
+
 		return "", fmt.Errorf("could not emit unrecognized top-level statement '%s'", stmt.TokenLiteral())
 	}
 
@@ -685,5 +692,23 @@ func emitMovementStatement(movementStmt *ast.MovementStatement) string {
 		}
 	}
 	sb.WriteString(fmt.Sprintf("\t%s\n", terminator))
+	return sb.String()
+}
+
+func emitMartStatement(martStmt *ast.MartStatement) string {
+	terminator := "ITEM_NONE"
+	var sb strings.Builder
+	if martStmt.Scope == token.GLOBAL {
+		sb.WriteString(fmt.Sprintf("%s::\n", martStmt.Name.Value))
+	} else {
+		sb.WriteString(fmt.Sprintf("%s:\n", martStmt.Name.Value))
+	}
+	for _, item := range martStmt.MartItems {
+		if item == terminator {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("\t.2byte %s\n", item))
+	}
+	sb.WriteString("\t.2byte ITEM_NONE\n\trelease\n\tend\n")
 	return sb.String()
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -199,6 +199,12 @@ func (p *Parser) parseTopLevelStatement() (ast.Statement, error) {
 			return nil, err
 		}
 		return statement, nil
+	case token.MART:
+		statement, err := p.parseMartStatement()
+		if err != nil {
+			return nil, err
+		}
+		return statement, nil
 	case token.MAPSCRIPTS:
 		statement, implicitTexts, err := p.parseMapscriptsStatement()
 		if err != nil {
@@ -753,6 +759,114 @@ func (p *Parser) parsePoryswitchMovementCases() (map[string][]string, error) {
 		}
 	}
 	return movementCases, nil
+}
+
+func (p *Parser) parseMartStatement() (*ast.MartStatement, error) {
+	statement := &ast.MartStatement{
+		Token:     p.curToken,
+		MartItems: []string{},
+	}
+	scope, err := p.parseScopeModifier(token.LOCAL)
+	if err != nil {
+		return nil, err
+	}
+	statement.Scope = scope
+	if err := p.expectPeek(token.IDENT); err != nil {
+		return nil, fmt.Errorf("line %d: missing name for mart statement", p.curToken.LineNumber)
+	}
+
+	statement.Name = &ast.Identifier{
+		Token: p.curToken,
+		Value: p.curToken.Literal,
+	}
+
+	if err := p.expectPeek(token.LBRACE); err != nil {
+		return nil, fmt.Errorf("line %d: missing opening curly brace for mart '%s'", p.peekToken.LineNumber, statement.Name.Value)
+	}
+	p.nextToken()
+	statement.MartItems, err = p.parseMartValue(true)
+	if err != nil {
+		return nil, err
+	}
+
+	return statement, nil
+}
+
+func (p *Parser) parseMartValue(allowMultiple bool) ([]string, error) {
+	martCommands := make([]string, 0)
+	for p.curToken.Type != token.RBRACE {
+		if p.curToken.Type == token.PORYSWITCH {
+			poryswitchCommands, err := p.parsePoryswitchMartStatement()
+			if err != nil {
+				return nil, err
+			}
+			martCommands = append(martCommands, poryswitchCommands...)
+		} else if p.curToken.Type == token.IDENT {
+			martCommand := p.curToken.Literal
+			p.nextToken()
+			martCommands = append(martCommands, martCommand)
+		} else {
+			return nil, fmt.Errorf("line %d: expected mart item, but got '%s' instead", p.curToken.LineNumber, p.curToken.Literal)
+		}
+		if !allowMultiple {
+			break
+		}
+	}
+	return martCommands, nil
+}
+
+func (p *Parser) parsePoryswitchMartStatement() ([]string, error) {
+	startLineNumber := p.curToken.LineNumber
+	switchCase, switchValue, err := p.parsePoryswitchHeader()
+	if err != nil {
+		return nil, err
+	}
+	cases, err := p.parsePoryswitchMartCases()
+	if err != nil {
+		return nil, err
+	}
+	items, ok := cases[switchValue]
+	if !ok {
+		items, ok = cases["_"]
+		if !ok {
+			return nil, fmt.Errorf("line %d: no poryswitch case found for '%s=%s', which was specified with the '-s' option", startLineNumber, switchCase, switchValue)
+		}
+	}
+	p.nextToken()
+	return items, nil
+}
+
+func (p *Parser) parsePoryswitchMartCases() (map[string][]string, error) {
+	martCases := make(map[string][]string)
+	startLineNumber := p.curToken.LineNumber
+	for p.curToken.Type != token.RBRACE {
+		if p.curToken.Type == token.EOF {
+			return nil, fmt.Errorf("line %d: missing closing curly braces for poryswitch statement", startLineNumber)
+		}
+		if p.curToken.Type != token.IDENT && p.curToken.Type != token.INT {
+			return nil, fmt.Errorf("line %d: invalid poryswitch case '%s'. Expected a simple identifier", p.curToken.LineNumber, p.curToken.Literal)
+		}
+		caseValue := p.curToken.Literal
+		p.nextToken()
+		if p.curToken.Type == token.COLON || p.curToken.Type == token.LBRACE {
+			usedBrace := p.curToken.Type == token.LBRACE
+			p.nextToken()
+			items, err := p.parseMartValue(usedBrace)
+			if err != nil {
+				return nil, err
+			}
+			martCases[caseValue] = items
+			if usedBrace {
+				if p.curToken.Type != token.RBRACE {
+					return nil, fmt.Errorf("line %d: missing closing curly brace for poryswitch case '%s'", startLineNumber, caseValue)
+				}
+				p.nextToken()
+			}
+		} else {
+			return nil, fmt.Errorf("line %d: invalid token '%s' after poryswitch case '%s'. Expected ':' or '{'", p.curToken.LineNumber, p.curToken.Literal, caseValue)
+		}
+	}
+	return martCases, nil
 }
 
 func (p *Parser) parseMapscriptsStatement() (*ast.MapScriptsStatement, []impText, error) {

--- a/token/token.go
+++ b/token/token.go
@@ -51,6 +51,7 @@ const (
 	RAW        = "RAW"
 	TEXT       = "TEXT"
 	MOVEMENT   = "MOVEMENT"
+	MART       = "MART"
 	MAPSCRIPTS = "MAPSCRIPTS"
 	FORMAT     = "FORMAT"
 	VAR        = "VAR"
@@ -85,6 +86,7 @@ var keywords = map[string]Type{
 	"raw":        RAW,
 	"text":       TEXT,
 	"movement":   MOVEMENT,
+	"mart":       MART,
 	"mapscripts": MAPSCRIPTS,
 	"format":     FORMAT,
 	"var":        VAR,


### PR DESCRIPTION
This adds the top-level statement `mart` which acts similarly to `movement`, allowing for the definition of item lists for the `pokemart` command without using raw.

```
mart MyMartItems {
	ITEM_LAVA_COOKIE
	ITEM_MOOMOO_MILK
	ITEM_RARE_CANDY
	ITEM_LEMONADE
	ITEM_BERRY_JUICE
}
```
Becomes:
```
MyMartItems:
	.2byte ITEM_LAVA_COOKIE
	.2byte ITEM_MOOMOO_MILK
	.2byte ITEM_RARE_CANDY
	.2byte ITEM_LEMONADE
	.2byte ITEM_BERRY_JUICE
	.2byte ITEM_NONE
	release
	end
```

Users do not need to add `ITEM_NONE` to the end of their `mart` lists, but no change in output will occur if they do. If `ITEM_NONE` is encountered mid-list, any subsequent items will be ignored to ensure the terminating commands are properly outputted. This check is performed on emission, not when parsing.

`mart` is fully compatible with embedded `poryswitch` statements (behaving exactly how they would in movement statements). Documentation has been updated in README and three new tests were added - One for the parser and two for the emitter.

The vscode poryscript extension will need to be updated.