### PR TITLE
Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ When not using implicit truthiness, like in the above examples, they each have d
 | `var` | any value (e.g. `5`, `VAR_TEMP_1`, `VAR_FOO + BASE_OFFSET`) |
 | `defeated` | `TRUE`, `true`, `FALSE`, `false` |
 
-One quirk of the Gen 3 decomp scripting engine is that using the `compare` scripting command with a value in the range `0x4000 <= x <= 0x40FF` or `0x8000 <= x <= 0x8015` will result in comparing agains a `var`, rather than the raw value. To force the comparison against a raw value, like `0x4000`, use the `value()` operator.  For example:
+One quirk of the Gen 3 decomp scripting engine is that using the `compare` scripting command with a value in the range `0x4000 <= x <= 0x40FF` or `0x8000 <= x <= 0x8015` will result in comparing against a `var`, rather than the raw value. To force the comparison against a raw value, like `0x4000`, use the `value()` operator.  For example:
 
 ```
 if (var(VAR_DAMAGE_DEALT) >= value(0x4000))


### PR DESCRIPTION
Changed "agains" to "against" near the end of the Conditional Operators section.