### PR TITLE
allow users to define a variable number of lines in font_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,17 @@ Becomes:
 .string "you!$"
 ```
 
+Finally, `format()` takes the following optional named parameters, which override settings from the font config:
+- `fontId`
+- `maxLineLength`
+- `numLines`
+- `cursorOverlapWidth`
+```
+text MyText {
+    format("This is an example of named parameters!", numLines=3, maxLineLength=100)
+}
+```
+
 ### Custom Text Encoding
 When Poryscript compiles text, the resulting text content is rendered using the `.string` assembler directive. The decomp projects' build process then processes those `.string` directives and substituted the string characters with the game-specific text representation. It can be useful to specify different types of strings, though. For example, implementing print-debugging commands might make use of ASCII text. Poryscript allows you to specify which assembler directive to use for text. Simply add the directive as a prefix to the string content like this:
 ```

--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ The font configuration JSON file informs Poryscript how many pixels wide each ch
 
 `cursorOverlapWidth` can be used to ensure there is always enough room for the cursor icon to be displayed in the text box. (This "cursor icon" is the small icon that's shown when the player needs to press A to advance the text box.)
 
+`numLines` is the number of lines displayed within a single message box. If editing text for a taller space, this can be adjusted in `font_config.json`.
+
 The length of a line can optionally be specified as the third parameter to `format()` if a font id was specified as the second parameter.
 
 ```

--- a/font_config.json
+++ b/font_config.json
@@ -2,7 +2,8 @@
   "defaultFontId": "1_latin_rse",
   "fonts": {
     "1_latin_rse": {
-      "maxLineLength": 208,
+      "originalmaxLineLength": 208,
+      "maxLineLength": 219,
       "widths": {
         " ": 3,
         "À": 6,

--- a/font_config.json
+++ b/font_config.json
@@ -2,8 +2,8 @@
   "defaultFontId": "1_latin_rse",
   "fonts": {
     "1_latin_rse": {
-      "originalmaxLineLength": 208,
-      "maxLineLength": 218,
+      "maxLineLength": 208,
+      "numLines": 2,
       "cursorOverlapWidth": 0,
       "widths": {
         " ": 3,
@@ -178,6 +178,7 @@
     },
     "1_latin_frlg": {
       "maxLineLength": 208,
+      "numLines": 2,
       "cursorOverlapWidth": 10,
       "widths": {
         " ": 6,

--- a/font_config.json
+++ b/font_config.json
@@ -3,7 +3,7 @@
   "fonts": {
     "1_latin_rse": {
       "originalmaxLineLength": 208,
-      "maxLineLength": 219,
+      "maxLineLength": 218,
       "widths": {
         " ": 3,
         "À": 6,

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -56,6 +56,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, fontID string) (stri
 	var curLineSb strings.Builder
 	curWidth := 0
 	isFirstLine := true
+    isSecondLine := false
 	isFirstWord := true
 	pos := 0
 	for pos < len(text) {
@@ -87,9 +88,15 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, fontID string) (stri
 			wordWidth += fc.getWordPixelWidth(word, fontID)
 			if curWidth+wordWidth > maxWidth && curLineSb.Len() > 0 {
 				formattedSb.WriteString(curLineSb.String())
-				if isFirstLine {
-					formattedSb.WriteString(`\n`)
-					isFirstLine = false
+                if isFirstLine {
+                    formattedSb.WriteString(`\n`)
+                    isFirstLine = false
+                    // Start 3_line_message_box
+                    isSecondLine = true
+                } else if isSecondLine {
+                    formattedSb.WriteString(`\n`)
+                    isSecondLine = false
+                    // End 3_line_message_box
 				} else {
 					formattedSb.WriteString(`\l`)
 				}

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -83,6 +83,8 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			formattedSb.WriteByte('\n')
 			if !fc.isParagraphBreak(word) {
 				curLineNum++
+			} else {
+				curLineNum = 0
 			}
 			isFirstWord = true
 			curLineSb.Reset()

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -103,7 +103,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			if nextWidth > maxWidth && curLineSb.Len() > 0 {
 				formattedSb.WriteString(curLineSb.String())
 
-				if fc.isMaxLineOrGreater(lineNumber, NumLines) {
+				if fc.shouldUseLineFeed(lineNumber, NumLines) {
 					formattedSb.WriteString(`\l`)
 				} else {
                     formattedSb.WriteString(`\n`)
@@ -138,7 +138,7 @@ func (fc *FontConfig) isFirstLine(lineNumber int) bool {
    return lineNumber == 1
 }
 
-func (fc *FontConfig) isMaxLineOrGreater(lineNumber int, NumLines int) bool {
+func (fc *FontConfig) shouldUseLineFeed(lineNumber int, NumLines int) bool {
    return lineNumber >= NumLines
 }
 

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -57,7 +57,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 	var formattedSb strings.Builder
 	var curLineSb strings.Builder
 	curWidth := 0
-	curLineNum := 1
+	curLineNum := 0
 	isFirstWord := true
 	spaceCharWidth := fc.getRunePixelWidth(' ', fontID)
 	pos, word := fc.getNextWord(text)
@@ -135,11 +135,11 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 }
 
 func (fc *FontConfig) isFirstLine(curLineNum int) bool {
-	return curLineNum == 1
+	return curLineNum == 0
 }
 
 func (fc *FontConfig) shouldUseLineFeed(curLineNum int, NumLines int) bool {
-	return curLineNum >= NumLines
+	return (curLineNum >= (NumLines - 1))
 }
 
 func (fc *FontConfig) getNextWord(text string) (int, string) {

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -103,9 +103,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			if nextWidth > maxWidth && curLineSb.Len() > 0 {
 				formattedSb.WriteString(curLineSb.String())
 
-                if fc.isFirstLine(lineNumber) {
-                    formattedSb.WriteString(`\n`)
-				} else if fc.isMaxLineOrGreater(lineNumber, NumLines) {
+				if fc.isMaxLineOrGreater(lineNumber, NumLines) {
 					formattedSb.WriteString(`\l`)
 				} else {
                     formattedSb.WriteString(`\n`)

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -19,7 +19,7 @@ type Fonts struct {
 	Widths             map[string]int `json:"widths"`
 	CursorOverlapWidth int            `json:"cursorOverlapWidth"`
 	MaxLineLength      int            `json:"maxLineLength"`
-    NumLines           int            `json:"numLines"`
+	NumLines           int            `json:"numLines"`
 }
 
 // LoadFontConfig reads a font width config JSON file.
@@ -57,7 +57,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 	var formattedSb strings.Builder
 	var curLineSb strings.Builder
 	curWidth := 0
-    lineNumber := 1
+	curLineNum := 1
 	isFirstWord := true
 	spaceCharWidth := fc.getRunePixelWidth(' ', fontID)
 	pos, word := fc.getNextWord(text)
@@ -72,7 +72,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			curWidth = 0
 			formattedSb.WriteString(curLineSb.String())
 			if fc.isAutoLineBreak(word) {
-                if fc.isFirstLine(lineNumber) {
+				if fc.isFirstLine(curLineNum) {
 					formattedSb.WriteString(`\n`)
 				} else {
 					formattedSb.WriteString(`\l`)
@@ -82,7 +82,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			}
 			formattedSb.WriteByte('\n')
 			if !fc.isParagraphBreak(word) {
-                lineNumber++
+				curLineNum++
 			}
 			isFirstWord = true
 			curLineSb.Reset()
@@ -97,19 +97,19 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			// it could span multiple words. The true solution would require optimistically trying to fit all
 			// remaining words onto the same line, rather than only looking at the current word + cursor. However,
 			// this is "good enough" and likely works for almost all actual use cases in practice.
-			if len(nextWord) > 0 && (fc.isFirstLine(lineNumber) == false || fc.isParagraphBreak(nextWord)) {
+			if len(nextWord) > 0 && (fc.isFirstLine(curLineNum) == false || fc.isParagraphBreak(nextWord)) {
 				nextWidth += cursorOverlapWidth
 			}
 			if nextWidth > maxWidth && curLineSb.Len() > 0 {
 				formattedSb.WriteString(curLineSb.String())
 
-				if fc.shouldUseLineFeed(lineNumber, NumLines) {
+				if fc.shouldUseLineFeed(curLineNum, NumLines) {
 					formattedSb.WriteString(`\l`)
 				} else {
-                    formattedSb.WriteString(`\n`)
-                }
+					formattedSb.WriteString(`\n`)
+				}
 
-                lineNumber++
+				curLineNum++
 				formattedSb.WriteByte('\n')
 				isFirstWord = false
 				curLineSb.Reset()
@@ -134,12 +134,12 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 	return formattedSb.String(), nil
 }
 
-func (fc *FontConfig) isFirstLine(lineNumber int) bool {
-   return lineNumber == 1
+func (fc *FontConfig) isFirstLine(curLineNum int) bool {
+	return curLineNum == 1
 }
 
-func (fc *FontConfig) shouldUseLineFeed(lineNumber int, NumLines int) bool {
-   return lineNumber >= NumLines
+func (fc *FontConfig) shouldUseLineFeed(curLineNum int, NumLines int) bool {
+	return curLineNum >= NumLines
 }
 
 func (fc *FontConfig) getNextWord(text string) (int, string) {

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -141,7 +141,7 @@ func (fc *FontConfig) isFirstLine(curLineNum int) bool {
 }
 
 func (fc *FontConfig) shouldUseLineFeed(curLineNum int, numLines int) bool {
-	return (curLineNum >= (numLines - 1))
+	return curLineNum >= numLines - 1
 }
 
 func (fc *FontConfig) getNextWord(text string) (int, string) {

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -99,7 +99,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			// it could span multiple words. The true solution would require optimistically trying to fit all
 			// remaining words onto the same line, rather than only looking at the current word + cursor. However,
 			// this is "good enough" and likely works for almost all actual use cases in practice.
-			if len(nextWord) > 0 && (fc.isFirstLine(curLineNum) == false || fc.isParagraphBreak(nextWord)) {
+			if len(nextWord) > 0 && (!fc.isFirstLine(curLineNum) || fc.isParagraphBreak(nextWord)) {
 				nextWidth += cursorOverlapWidth
 			}
 			if nextWidth > maxWidth && curLineSb.Len() > 0 {

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -81,10 +81,10 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 				formattedSb.WriteString(word)
 			}
 			formattedSb.WriteByte('\n')
-			if !fc.isParagraphBreak(word) {
-				curLineNum++
-			} else {
+			if fc.isParagraphBreak(word) {
 				curLineNum = 0
+			} else {
+				curLineNum++
 			}
 			isFirstWord = true
 			curLineSb.Reset()
@@ -99,12 +99,11 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			// it could span multiple words. The true solution would require optimistically trying to fit all
 			// remaining words onto the same line, rather than only looking at the current word + cursor. However,
 			// this is "good enough" and likely works for almost all actual use cases in practice.
-			if len(nextWord) > 0 && (!fc.isFirstLine(curLineNum) || fc.isParagraphBreak(nextWord)) {
+			if len(nextWord) > 0 && (curLineNum >= numLines-1 || fc.isParagraphBreak(nextWord)) {
 				nextWidth += cursorOverlapWidth
 			}
 			if nextWidth > maxWidth && curLineSb.Len() > 0 {
 				formattedSb.WriteString(curLineSb.String())
-
 				if fc.shouldUseLineFeed(curLineNum, numLines) {
 					formattedSb.WriteString(`\l`)
 				} else {

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -141,7 +141,7 @@ func (fc *FontConfig) isFirstLine(curLineNum int) bool {
 }
 
 func (fc *FontConfig) shouldUseLineFeed(curLineNum int, numLines int) bool {
-	return curLineNum >= numLines - 1
+	return curLineNum >= numLines-1
 }
 
 func (fc *FontConfig) getNextWord(text string) (int, string) {

--- a/parser/formattext.go
+++ b/parser/formattext.go
@@ -41,7 +41,7 @@ const testFontID = "TEST"
 
 // FormatText automatically inserts line breaks into text
 // according to in-game text box widths.
-func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth int, fontID string, NumLines int) (string, error) {
+func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth int, fontID string, numLines int) (string, error) {
 	if !fc.isFontIDValid(fontID) && len(fontID) > 0 && fontID != testFontID {
 		validFontIDs := make([]string, len(fc.Fonts))
 		i := 0
@@ -103,7 +103,7 @@ func (fc *FontConfig) FormatText(text string, maxWidth int, cursorOverlapWidth i
 			if nextWidth > maxWidth && curLineSb.Len() > 0 {
 				formattedSb.WriteString(curLineSb.String())
 
-				if fc.shouldUseLineFeed(curLineNum, NumLines) {
+				if fc.shouldUseLineFeed(curLineNum, numLines) {
 					formattedSb.WriteString(`\l`)
 				} else {
 					formattedSb.WriteString(`\n`)
@@ -138,8 +138,8 @@ func (fc *FontConfig) isFirstLine(curLineNum int) bool {
 	return curLineNum == 0
 }
 
-func (fc *FontConfig) shouldUseLineFeed(curLineNum int, NumLines int) bool {
-	return (curLineNum >= (NumLines - 1))
+func (fc *FontConfig) shouldUseLineFeed(curLineNum int, numLines int) bool {
+	return (curLineNum >= (numLines - 1))
 }
 
 func (fc *FontConfig) getNextWord(text string) (int, string) {

--- a/parser/formattext_test.go
+++ b/parser/formattext_test.go
@@ -33,7 +33,7 @@ func TestFormatText(t *testing.T) {
 	fc := FontConfig{}
 
 	for i, tt := range tests {
-		result, _ := fc.FormatText(tt.inputText, tt.maxWidth, tt.cursorOverlapWidth, testFontID)
+		result, _ := fc.FormatText(tt.inputText, tt.maxWidth, tt.cursorOverlapWidth, testFontID, 2)
 		if result != tt.expected {
 			t.Errorf("FormatText Test %d: Expected '%s', but Got '%s'", i, tt.expected, result)
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -61,15 +61,14 @@ type Parser struct {
 // New creates a new Poryscript AST Parser.
 func New(l *lexer.Lexer, fontConfigFilepath string, defaultFontID string, maxLineLength int, compileSwitches map[string]string) *Parser {
 	p := &Parser{
-		l:                       l,
-		inlineTexts:             make([]ast.Text, 0),
-		inlineTextsSet:          make(map[textKey]string),
-		inlineTextCounts:        make(map[string]int),
-		textStatements:          make([]*ast.TextStatement, 0),
-		fontConfigFilepath:      fontConfigFilepath,
-		defaultFontID:           defaultFontID,
-		maxLineLength:           maxLineLength,
-		numLines:                maxLineLength,
+		l:                  l,
+		inlineTexts:        make([]ast.Text, 0),
+		inlineTextsSet:     make(map[textKey]string),
+		inlineTextCounts:   make(map[string]int),
+		textStatements:     make([]*ast.TextStatement, 0),
+		fontConfigFilepath: fontConfigFilepath,
+		defaultFontID:      defaultFontID,
+		maxLineLength:      maxLineLength,
 		compileSwitches:         compileSwitches,
 		constants:               make(map[string]string),
 		enableEnvironmentErrors: true,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1144,17 +1144,16 @@ func (p *Parser) parseFormatStringOperator() (token.Token, string, string, error
 		return token.Token{}, "", "", NewParseError(p.curToken, "missing closing parenthesis ')' for format()")
 	}
 
-	if maxTextLength <= 0 {
-		maxTextLength = p.fonts.Fonts[fontID].MaxLineLength
+	setEmptyParametersToDefault := func(paramName string, paramValue *int, defaultValue int) {
+		if *paramValue <= 0 {
+			//log.Printf("WARNING: %s was not defined, so the default value from the specified fontID is being used.\n", paramName)
+			*paramValue = defaultValue
+		}
 	}
 
-	if numLines <= 0 {
-		numLines = p.fonts.Fonts[fontID].NumLines
-	}
-
-	if cursorOverlapWidth <= 0 {
-		cursorOverlapWidth = p.fonts.Fonts[fontID].CursorOverlapWidth
-	}
+	setEmptyParametersToDefault("maxTextLength", &maxTextLength, p.fonts.Fonts[fontID].MaxLineLength)
+	setEmptyParametersToDefault("numLines", &numLines, p.fonts.Fonts[fontID].NumLines)
+	setEmptyParametersToDefault("cursorOverlapWidth", &cursorOverlapWidth, p.fonts.Fonts[fontID].CursorOverlapWidth)
 
 	formatted, err := p.fonts.FormatText(textToken.Literal, maxTextLength, cursorOverlapWidth, fontID, numLines)
 	if err != nil && p.enableEnvironmentErrors {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -52,8 +52,6 @@ type Parser struct {
 	defaultFontID           string
 	fonts                   *FontConfig
 	maxLineLength           int
-	numLines                int
-	cursorOverlapWidth      int
 	compileSwitches         map[string]string
 	constants               map[string]string
 	enableEnvironmentErrors bool
@@ -1046,6 +1044,20 @@ func (p *Parser) parseMapscriptsStatement() (*ast.MapScriptsStatement, []impText
 	return statement, implicitTexts, nil
 }
 
+const (
+	formatParamFontId             = "fontId"
+	formatParamMaxLineLength      = "maxLineLength"
+	formatParamNumLines           = "numLines"
+	formatParamCursorOverlapWidth = "cursorOverlapWidth"
+)
+
+var namedParameters = map[string]struct{}{
+	formatParamFontId:             {},
+	formatParamMaxLineLength:      {},
+	formatParamNumLines:           {},
+	formatParamCursorOverlapWidth: {},
+}
+
 func (p *Parser) parseFormatStringOperator() (token.Token, string, string, error) {
 	if err := p.expectPeek(token.LPAREN); err != nil {
 		return token.Token{}, "", "", NewRangeParseError(p.curToken, p.peekToken, "format operator must begin with an open parenthesis '('")
@@ -1076,136 +1088,120 @@ func (p *Parser) parseFormatStringOperator() (token.Token, string, string, error
 		}
 	}
 
-	maxTextLength := p.maxLineLength
-	numLines := p.numLines
-	cursorOverlapWidth := p.cursorOverlapWidth
-	paramValue := ""
+	maxLineLength := p.maxLineLength
+	numLines := -1
+	cursorOverlapWidth := -1
 
-	namedParameters := map[string]func() error{
-		"fontId": func() error {
-			if (fontID != p.defaultFontID) && (fontID != p.fonts.DefaultFontID) {
-				return p.reportDuplicateParameterError("fontId", fontID, paramValue)
+	if p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		// format()'s api is a mess... In the name of backwards compatibility, it supports specifying the font and/or max line length as
+		// unnamed parameters in either order. After those, a collection of named parameters are supported.
+		expectingNamedParam := true
+		hadParam := false
+		if p.peekTokenIs(token.INT) || p.peekTokenIs(token.STRING) {
+			// Handle the font id and max line length unnamed parameters.
+			hadParam = true
+			if p.peekTokenIs(token.STRING) {
+				p.nextToken()
+				fontID = p.curToken.Literal
+				fontIdToken = p.curToken
+				if p.peekTokenIs(token.COMMA) && !p.peek2TokenIs(token.IDENT) {
+					p.nextToken()
+					if err := p.expectPeek(token.INT); err != nil {
+						return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid format() maxLineLength '%s'. Expected integer", p.peekToken.Literal))
+					}
+					num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
+					maxLineLength = int(num)
+				}
+			} else {
+				p.nextToken()
+				num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
+				maxLineLength = int(num)
+				if p.peekTokenIs(token.COMMA) && !p.peek2TokenIs(token.IDENT) {
+					p.nextToken()
+					if err := p.expectPeek(token.STRING); err != nil {
+						return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid format() fontId '%s'. Expected string", p.peekToken.Literal))
+					}
+					fontID = p.curToken.Literal
+					fontIdToken = p.curToken
+				}
 			}
-			fontID = paramValue
-			fontIdToken = p.peekToken
-			return nil
-		},
-		"maxLineLength": func() error {
-			if maxTextLength != p.maxLineLength {
-				return p.reportDuplicateParameterError("maxLineLength", strconv.Itoa(maxTextLength), paramValue)
+			expectingNamedParam = p.peekTokenIs(token.COMMA)
+			if expectingNamedParam {
+				p.nextToken()
 			}
-			num, _ := strconv.ParseInt(paramValue, 0, 64)
-			maxTextLength = int(num)
-			return nil
-		},
-		"numLines": func() error {
-			if numLines != p.numLines {
-				return p.reportDuplicateParameterError("numLines", strconv.Itoa(numLines), paramValue)
-			}
-			num, _ := strconv.ParseInt(paramValue, 0, 64)
-			numLines = int(num)
-			return nil
-		},
-		"cursorOverlapWidth": func() error {
-			if cursorOverlapWidth != p.cursorOverlapWidth {
-				return p.reportDuplicateParameterError("cursorOverlapWidth", strconv.Itoa(cursorOverlapWidth), paramValue)
-			}
-			num, _ := strconv.ParseInt(paramValue, 0, 64)
-			cursorOverlapWidth = int(num)
-			return nil
-		},
-	}
-
-	for !p.peekTokenIs(token.RPAREN) {
-		if !p.peekTokenIs(token.COMMA) {
-			return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid format() parameter '%s'. Expected a comma", p.peekToken.Literal))
 		}
 
-		p.nextToken()
+		if expectingNamedParam {
+			// Now, handle named parameters
+			for p.peekTokenIs(token.IDENT) {
+				hadParam = true
+				p.nextToken()
+				if _, ok := namedParameters[p.curToken.Literal]; !ok {
+					return token.Token{}, "", "", NewParseError(p.curToken, fmt.Sprintf("invalid format() named parameter '%s'", p.curToken.Literal))
+				}
+				paramName := p.curToken.Literal
+				if err := p.expectPeek(token.ASSIGN); err != nil {
+					return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("missing '=' after format() named parameter '%s'", paramName))
+				}
 
-		if p.peekTokenIs(token.INT) || !isNamedParameter(p.peekToken.Literal, namedParameters) {
-			if err := p.handleUnnamedParameter(&maxTextLength, &fontID, &fontIdToken); err != nil {
-				return token.Token{}, "", "", err
-			}
+				switch paramName {
+				case formatParamFontId:
+					if err := p.expectPeek(token.STRING); err != nil {
+						return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid %s '%s'. Expected string", formatParamFontId, p.peekToken.Literal))
+					}
+					fontID = p.curToken.Literal
+					fontIdToken = p.curToken
+				case formatParamMaxLineLength:
+					if err := p.expectPeek(token.INT); err != nil {
+						return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid %s '%s'. Expected integer", formatParamMaxLineLength, p.peekToken.Literal))
+					}
+					num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
+					maxLineLength = int(num)
+				case formatParamNumLines:
+					if err := p.expectPeek(token.INT); err != nil {
+						return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid %s '%s'. Expected integer", formatParamNumLines, p.peekToken.Literal))
+					}
+					num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
+					numLines = int(num)
+				case formatParamCursorOverlapWidth:
+					if err := p.expectPeek(token.INT); err != nil {
+						return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid %s '%s'. Expected integer", formatParamCursorOverlapWidth, p.peekToken.Literal))
+					}
+					num, _ := strconv.ParseInt(p.curToken.Literal, 0, 64)
+					cursorOverlapWidth = int(num)
+				}
 
-			p.nextToken()
-			continue
-		} else {
-			paramName := p.peekToken.Literal
-			if err := p.handleNamedParameter(paramName, namedParameters, &paramValue); err != nil {
-				return token.Token{}, "", "", err
+				if p.peekTokenIs(token.COMMA) {
+					p.nextToken()
+				}
 			}
+		}
+
+		if !hadParam {
+			return token.Token{}, "", "", NewParseError(p.peekToken, fmt.Sprintf("invalid format() parameter '%s'", p.peekToken.Literal))
 		}
 	}
 	if err := p.expectPeek(token.RPAREN); err != nil {
-		return token.Token{}, "", "", NewParseError(p.curToken, "missing closing parenthesis ')' for format()")
+		return token.Token{}, "", "", NewParseError(p.peekToken, "missing closing parenthesis ')' for format()")
 	}
 
-	setEmptyParametersToDefault := func(paramName string, paramValue *int, defaultValue int) {
-		if *paramValue <= 0 {
-			//log.Printf("WARNING: %s was not defined, so the default value from the specified fontID is being used.\n", paramName)
-			*paramValue = defaultValue
-		}
+	// Read default values from font config, if they weren't explicitly specified.
+	if maxLineLength <= 0 {
+		maxLineLength = p.fonts.Fonts[fontID].MaxLineLength
+	}
+	if numLines <= 0 {
+		numLines = p.fonts.Fonts[fontID].NumLines
+	}
+	if cursorOverlapWidth <= 0 {
+		cursorOverlapWidth = p.fonts.Fonts[fontID].CursorOverlapWidth
 	}
 
-	setEmptyParametersToDefault("maxTextLength", &maxTextLength, p.fonts.Fonts[fontID].MaxLineLength)
-	setEmptyParametersToDefault("numLines", &numLines, p.fonts.Fonts[fontID].NumLines)
-	setEmptyParametersToDefault("cursorOverlapWidth", &cursorOverlapWidth, p.fonts.Fonts[fontID].CursorOverlapWidth)
-
-	formatted, err := p.fonts.FormatText(textToken.Literal, maxTextLength, cursorOverlapWidth, fontID, numLines)
+	formatted, err := p.fonts.FormatText(textToken.Literal, maxLineLength, cursorOverlapWidth, fontID, numLines)
 	if err != nil && p.enableEnvironmentErrors {
 		return token.Token{}, "", "", NewParseError(fontIdToken, err.Error())
 	}
 	return textToken, formatted, stringType, nil
-}
-
-func (p *Parser) reportDuplicateParameterError(paramName string, oldValue string, newValue string) error {
-	return NewParseError(p.peekToken, fmt.Sprintf("'%s' was already set to '%s', attempted change to: '%s'", paramName, oldValue, newValue))
-}
-
-func isNamedParameter(paramName string, namedParameters map[string]func() error) bool {
-	_, ok := namedParameters[paramName]
-	return ok
-}
-
-func (p *Parser) handleNamedParameter(paramName string, namedParameters map[string]func() error, paramValue *string) error {
-	setNamedParameters, ok := namedParameters[paramName]
-	if !ok {
-		return NewParseError(p.curToken, fmt.Sprintf("invalid format() parameter '%s'. Expected one of the following: fontId (string), maxLineLength (integer), cursorOverlapWidth (integer), numLines (integer).", paramName))
-	}
-
-	p.nextToken()
-
-	if !p.peekTokenIs(token.ASSIGN) {
-		return NewParseError(p.peekToken, fmt.Sprintf("invalid format() parameter '%s'. Expected an equals sign", p.peekToken.Literal))
-	}
-
-	p.nextToken()
-	*paramValue = p.peekToken.Literal
-	err := setNamedParameters()
-	if err != nil {
-		return err
-	}
-	p.nextToken()
-
-	return nil
-}
-
-func (p *Parser) handleUnnamedParameter(maxTextLength *int, fontID *string, fontIdToken *token.Token) error {
-	if p.peekTokenIs(token.INT) {
-		if *maxTextLength != p.maxLineLength {
-			return p.reportDuplicateParameterError("maxTextLength", strconv.Itoa(*maxTextLength), p.peekToken.Literal)
-		}
-		num, _ := strconv.ParseInt(p.peekToken.Literal, 0, 64)
-		*maxTextLength = int(num)
-	} else {
-		if *fontID != p.defaultFontID && *fontID != p.fonts.DefaultFontID {
-			return p.reportDuplicateParameterError("fontId", *fontID, p.peekToken.Literal)
-		}
-		*fontID = p.peekToken.Literal
-		*fontIdToken = p.peekToken
-	}
-	return nil
 }
 
 func (p *Parser) parseIfStatement(scriptName string) (*ast.IfStatement, []impText, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1084,6 +1084,14 @@ func (p *Parser) parseFormatStringOperator() (token.Token, string, string, error
 		}
 
 		p.nextToken()
+
+        if p.peekTokenIs(token.INT) {
+            num, _ := strconv.ParseInt(p.peekToken.Literal, 0, 64)
+			maxTextLength = int(num)
+            p.nextToken()
+            continue;
+        }
+
 		paramName := p.peekToken.Literal
 		p.nextToken()
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1114,7 +1114,7 @@ func (p *Parser) parseFormatStringOperator() (token.Token, string, string, error
 		maxTextLength = p.fonts.Fonts[fontID].MaxLineLength
 	}
 
-	formatted, err := p.fonts.FormatText(textToken.Literal, maxTextLength, p.fonts.Fonts[fontID].CursorOverlapWidth, fontID)
+	formatted, err := p.fonts.FormatText(textToken.Literal, maxTextLength, p.fonts.Fonts[fontID].CursorOverlapWidth, fontID, p.fonts.Fonts[fontID].NumLines)
 	if err != nil && p.enableEnvironmentErrors {
 		return token.Token{}, "", "", NewParseError(fontIdToken, err.Error())
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1956,6 +1956,38 @@ text Foo {
 		},
 		{
 			input: `
+text Foo {
+	format("Hi", cursorOverlapWidth=3, 100)
+}`,
+			expectedError:      ParseError{LineNumberStart: 3, LineNumberEnd: 3, CharStart: 36, Utf8CharStart: 36, CharEnd: 39, Utf8CharEnd: 39, Message: "invalid parameter '100'. Expected named parameter"},
+			expectedErrorRegex: `line 3: invalid parameter '100'. Expected named parameter`,
+		},
+		{
+			input: `
+text Foo {
+	format("Hi", cursorOverlapWidth=3, cursorOverlapWidth=4)
+}`,
+			expectedError:      ParseError{LineNumberStart: 3, LineNumberEnd: 3, CharStart: 36, Utf8CharStart: 36, CharEnd: 54, Utf8CharEnd: 54, Message: "duplicate parameter 'cursorOverlapWidth'"},
+			expectedErrorRegex: `line 3: duplicate parameter 'cursorOverlapWidth'`,
+		},
+		{
+			input: `
+text Foo {
+	format("Hi", "fakeFont", fontId="otherfont)
+}`,
+			expectedError:      ParseError{LineNumberStart: 3, LineNumberEnd: 3, CharStart: 26, Utf8CharStart: 26, CharEnd: 32, Utf8CharEnd: 32, Message: "duplicate parameter 'fontId'"},
+			expectedErrorRegex: `line 3: duplicate parameter 'fontId'`,
+		},
+		{
+			input: `
+text Foo {
+	format("Hi", 100, maxLineLength=50)
+}`,
+			expectedError:      ParseError{LineNumberStart: 3, LineNumberEnd: 3, CharStart: 19, Utf8CharStart: 19, CharEnd: 32, Utf8CharEnd: 32, Message: "duplicate parameter 'maxLineLength'"},
+			expectedErrorRegex: `line 3: duplicate parameter 'maxLineLength'`,
+		},
+		{
+			input: `
 mapscripts {
 }`,
 			expectedError:    ParseError{LineNumberStart: 2, LineNumberEnd: 2, CharStart: 0, Utf8CharStart: 0, CharEnd: 12, Utf8CharEnd: 12, Message: "missing name for mapscripts statement"},


### PR DESCRIPTION
[Original Discussion](https://discord.com/channels/442462691542695948/1149124008353206322/1149124387711229973)

This allow users to define an arbitrary number of lines for their message boxes, and poryscript will format text accordingly.

# `numLines` == 3
![vKtDg6u](https://github.com/huderlem/poryscript/assets/77138753/c58442e0-67a5-432a-8aaa-64165d0d9b85)

# `numLines` == 2
![XEjaxDe](https://github.com/huderlem/poryscript/assets/77138753/d0303e85-d240-411a-a347-c8448e478ca2)
