### PR TITLE
Update install instructions for Gen 3 repo Makefile changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ clean-assets:
 + %.pory: ;
 ```
 ```diff
-%.rl: % ; $(GFX) $< $@
+%.rl:     %      ; $(GFX) $< $@
 + data/%.inc: data/%.pory; $(SCRIPT) -i $< -o $@ -fc tools/poryscript/font_config.json -cc tools/poryscript/command_config.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ It's also a good idea to add `tools/poryscript` to your `.gitignore` before your
 
 2. Update the Makefile with these changes (Note, don't add the `+` symbol at the start of the lines. That's just to show the line is being added.):
 ```diff
-FIX := tools/gbafix/gbafix$(EXE)
-MAPJSON := tools/mapjson/mapjson$(EXE)
-JSONPROC := tools/jsonproc/jsonproc$(EXE)
-+ SCRIPT := tools/poryscript/poryscript$(EXE)
+FIX       := $(TOOLS_DIR)/gbafix/gbafix$(EXE)
+MAPJSON   := $(TOOLS_DIR)/mapjson/mapjson$(EXE)
+JSONPROC  := $(TOOLS_DIR)/jsonproc/jsonproc$(EXE)
++ SCRIPT    := $(TOOLS_DIR)/poryscript/poryscript$(EXE)
 ```
 ```diff
-mostlyclean: tidynonmodern tidymodern
+clean-assets:
 	...
-	rm -f $(AUTO_GEN_TARGETS)
-	@$(MAKE) clean -C libagbsyscall
+	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.rl' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -exec rm {} +
+	find $(DATA_ASM_SUBDIR)/maps \( -iname 'connections.inc' -o -iname 'events.inc' -o -iname 'header.inc' \) -exec rm {} +
 +	rm -f $(patsubst %.pory,%.inc,$(shell find data/ -type f -name '*.pory'))
 ```
 ```diff
@@ -112,7 +112,7 @@ mostlyclean: tidynonmodern tidymodern
 + %.pory: ;
 ```
 ```diff
-sound/%.bin: sound/%.aif ; $(AIF) $< $@
+%.rl: % ; $(GFX) $< $@
 + data/%.inc: data/%.pory; $(SCRIPT) -i $< -o $@ -fc tools/poryscript/font_config.json -cc tools/poryscript/command_config.json
 ```
 


### PR DESCRIPTION
Updates the install instructions to account for recent changes to the Makefiles in pret's pokeemerald and pokefirered repos. Tested these new changes on a clean pokeemerald repo and the current PR branch for pokefirered.

For reference:
- pret/pokeemerald#1949
- pret/pokeemerald#1950
- pret/pokeemerald#1957
- pret/pokefirered#672