### PR TITLE
Fix Github CI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If you want Github CI to automatically build and test your project, edit `.githu
     - name: Checkout repository
       uses: actions/checkout@v2
 +     with:
-+       submodules: --recursive
++       submodules: recursive
 ```
 
 ## Convert Existing Scripts


### PR DESCRIPTION
`--recursive` is not an option for `actions/checkout`.
The correct option is `recursive`.

See others who ran into this issue thinking that: https://github.com/actions/checkout/issues/34