### PR TITLE
Add aarch64 support

### DIFF
--- a/.github/workflows/go-dev.yml
+++ b/.github/workflows/go-dev.yml
@@ -57,6 +57,54 @@ jobs:
         files: poryscript-linux.zip
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-linux-arm64:
+    name: Build & Test on ubuntu-24.04-arm (linux/arm64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - name: Set up Go 1.19
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -coverprofile=coverage-arm64.txt -covermode=atomic ./...
+
+    - name: Verify ARM64 Binary
+      run: file poryscript
+
+    - name: Prep Release Directory
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        mkdir poryscript-linux-arm64
+        cp poryscript poryscript-linux-arm64
+        cp font_config.json poryscript-linux-arm64
+        cp command_config.json poryscript-linux-arm64
+        cp CHANGELOG.md poryscript-linux-arm64
+        cp README.md poryscript-linux-arm64
+
+    - name: Bundle Release Directory
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: montudor/action-zip@v0.1.0
+      with:
+        args: zip -r poryscript-linux-arm64.zip poryscript-linux-arm64
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: poryscript-linux-arm64.zip
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-mac:
     name: Build & Test on macos-latest
     runs-on: macos-latest


### PR DESCRIPTION
**CI/CD Workflow Enhancements:**

* Added a new `build-linux-arm64` job to `.github/workflows/go-dev.yml` to build and test the project on `ubuntu-24.04-arm` runners, including steps for dependency installation, building, testing, and binary verification.
* Included steps to package and release ARM64 binaries when a tag is pushed, ensuring ARM64 artifacts are available alongside existing releases.